### PR TITLE
Fixing the reformatting and wrap for asian language

### DIFF
--- a/ftplugin/rst_tables.vim
+++ b/ftplugin/rst_tables.vim
@@ -253,7 +253,7 @@ def get_unicode(string):
 def reflow_row_contents(row, widths):
     new_row = []
     for i, field in enumerate(row):
-        string = get_unicode(field.replace('\n', ' '))
+        string = get_unicode(field.replace('\n', ''))
         wrapped_lines = wrap(string, widths[i])
         new_row.append("\n".join(wrapped_lines).encode('utf-8'))
     return new_row


### PR DESCRIPTION
Fix the size calculation in reformatting for asian language, also write a simple wrap function since the default one might cut wide char.
