### PR TITLE
README: fix usage instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Usage
       This is paragraph text *after* the table.
 
 2. Put your cursor somewhere in the table.
-3. Press ``,,f`` (to create the table).  The output will look something like
+3. Press ``,,c`` (to create the table).  The output will look something like
    this::
 
       This is paragraph text *before* the table.
@@ -53,3 +53,5 @@ Usage
       +----------+---------------------------------------------------------+
 
       This is paragraph text *after* the table.
+
+4. If you need to make changes to the table after it's been created use ``,,f`` to "reflow" the table.


### PR DESCRIPTION
The usage instructions suggest using `,,f` to create the table, however, doing this before the table has been created with `,,c` produces an error:

```
Error detected while processing function ReflowTable:                                                                                                                                                                                                                                                                          
line    7:                                                                                                                                                                                                                                                                                                                     
Traceback (most recent call last):                                                                                                                                                                                                                                                                                             
  File "<string>", line 3, in <module>                                                                                                                                                                                                                                                                                         
  File "<string>", line 289, in reflow_table                                                                                                                                                                                                                                                                                   
  File "<string>", line 204, in get_column_widths_from_border_spec                                                                                                                                                                                                                                                             
RuntimeError: Cannot reflow this table. Top table border not found.                                                                                                                                                                                                                                                            
Press ENTER or type command to continue    
```

Updated the usage instructions to create the table with `,,c` first and show an example of using `,,f` to reflow the table after it's been modified.