### PR TITLE
Add check to be able to create a top page table

### DIFF
--- a/ftplugin/rst_tables.vim
+++ b/ftplugin/rst_tables.vim
@@ -28,7 +28,7 @@ def get_table_bounds():
     row, col = vim.current.window.cursor
     upper = lower = row
     try:
-        while vim.current.buffer[upper - 1].strip():
+        while vim.current.buffer[upper - 1].strip() and upper > 0:
             upper -= 1
     except IndexError:
         pass


### PR DESCRIPTION
This commit adds a check for top boundary, so if the table
goes up to the top of the document, it will be correctly detected.
